### PR TITLE
Adding free Embedded IDEs ressources

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ PCB design, debugging, simulation, CI, IoT backends, RF, TinyML, and more.
 | [LibrePCB](https://librepcb.org/) | Fully free and open | Smaller community than KiCad, but unrestricted. |
 | [Quilter](https://www.quilter.ai/) (AI routing) | Free tier, full routing engine | Add-on for KiCad/Altium/Cadence, not a full EDA suite. Free-tier designs may be used for model training; avoid proprietary designs. |
 
+## :desktop_computer: Embedded IDEs & Editor Extensions
+
+| Tool | What's Free | Notes |
+|---|---|---|
+| [Arduino IDE](https://www.arduino.cc/en/software) | Free, open-source IDE for Arduino sketches | Beginner-friendly; supports boards and libraries through built-in managers. Best for Arduino-style workflows. |
+| [STM32CubeIDE](https://www.st.com/en/development-tools/stm32cubeide.html) | Free IDE for STM32 development | Eclipse-based desktop IDE plus newer VS Code-based variant; mainly useful inside the STM32 ecosystem. |
+| [PlatformIO IDE](https://platformio.org/) | Free editor integration around PlatformIO Core | Strong multi-board workflow; often used through VS Code. |
+
 ## :mag: Debug Probes & JTAG/SWD
 
 | Tool | What's Free | Notes |


### PR DESCRIPTION
## What does this PR do?

- [X] Adds a new entry
- [ ] Fixes/updates an existing entry
- [X] Adds a new section
- [ ] Other (describe below)

## Checklist

- [X] Entry links to the official site (not a reseller/affiliate link)
- [X] "What's Free" column is accurate and specific
- [X] Real limits/gotchas are noted (non-commercial only, rate limits, signup required, etc.)
- [X] Placed in the most relevant existing section (or a clear case is made for a new one)

## Notes for reviewers

I personnaly have used ArduinoIDE and platformIO a lot and I would recommend these tools for beginners since they are very useful for embedded programming ( mainly for hobbyists). I am starting with STM32 and when looking up on internet I saw that the main IDE that developpers are using for this collection of chips is STMCubeIDE.

